### PR TITLE
Add multipage Streamlit trading desktop skeleton

### DIFF
--- a/streamlit_app/Home.py
+++ b/streamlit_app/Home.py
@@ -1,0 +1,50 @@
+"""Landing page for the trading desktop suite."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import streamlit as st
+
+from utils import db
+
+
+def ensure_environment() -> None:
+    db.init_db()
+    data_dir = Path(__file__).resolve().parent / "data"
+    data_dir.mkdir(exist_ok=True)
+
+
+def main() -> None:
+    st.set_page_config(page_title="Trader Control Center", layout="wide")
+    ensure_environment()
+
+    st.title("📊 Trader Control Center")
+    st.write(
+        "Welcome to the all-in-one desktop suite for journaling, analytics, risk and strategy tooling."
+    )
+    st.success(
+        "Use the sidebar navigation to access the 20 dedicated workspaces. "
+        "All data is stored locally in SQLite (`app.db`) and the `data/` folder for maximum privacy."
+    )
+
+    st.header("Quick Start")
+    st.markdown(
+        """
+        1. Upload or log your first trades via **Trading Journal**.
+        2. Explore **Performance Analytics** to review stats.
+        3. Configure your **Risk Dashboard** profile in the settings area.
+        4. Import or build strategies in the **Strategy Vault**.
+        5. Assemble baskets, run backtests, and export polished reports.
+        """
+    )
+
+    st.header("Demo Data Toggle")
+    st.info(
+        "Turn on demo data on each page to explore the workflows before importing your own trades."
+    )
+
+    st.caption("Desktop build ready — use PyInstaller or Streamlit's native packaging to ship.")
+
+
+if __name__ == "__main__":
+    main()

--- a/streamlit_app/pages/10_🎲_Monte_Carlo.py
+++ b/streamlit_app/pages/10_🎲_Monte_Carlo.py
@@ -1,0 +1,42 @@
+"""Monte Carlo simulator page."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import streamlit as st
+
+PARENT = Path(__file__).resolve().parents[1]
+if str(PARENT) not in sys.path:
+    sys.path.append(str(PARENT))
+
+
+def monte_carlo_paths(returns: pd.Series, paths: int = 100) -> pd.DataFrame:
+    sims = []
+    for _ in range(paths):
+        resampled = returns.sample(len(returns), replace=True).reset_index(drop=True)
+        sims.append((1 + resampled).cumprod())
+    return pd.DataFrame(sims).T
+
+
+def main() -> None:
+    st.title("🎲 Monte Carlo Simulator")
+    st.caption("Bootstrap equity paths to stress test the edge.")
+
+    paths = st.slider("Paths", min_value=10, max_value=500, value=100)
+    returns = pd.Series(np.random.normal(0.002, 0.01, 200))
+    paths_df = monte_carlo_paths(returns, paths)
+    st.line_chart(paths_df, height=250)
+
+    percentiles = paths_df.iloc[-1].quantile([0.05, 0.5, 0.95])
+    st.write("Terminal equity percentiles", percentiles)
+
+    st.subheader("Drawdown distribution")
+    dd = paths_df.apply(lambda col: col / col.cummax() - 1)
+    st.area_chart(dd, height=200)
+
+
+if __name__ == "__main__":
+    main()

--- a/streamlit_app/pages/11_🌊_Drawdown_Regimes.py
+++ b/streamlit_app/pages/11_🌊_Drawdown_Regimes.py
@@ -1,0 +1,43 @@
+"""Drawdown and regime analysis."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import streamlit as st
+
+PARENT = Path(__file__).resolve().parents[1]
+if str(PARENT) not in sys.path:
+    sys.path.append(str(PARENT))
+
+
+def main() -> None:
+    st.title("🌊 Drawdown & Regime Analyzer")
+    st.caption("Segment equity curve into regimes and surface pain periods.")
+
+    equity = pd.Series(np.cumprod(1 + np.random.normal(0.001, 0.01, 250)) * 10000)
+    drawdown = equity / equity.cummax() - 1
+    st.area_chart(drawdown, height=200)
+
+    st.subheader("Regime segmentation")
+    rolling_vol = equity.pct_change().rolling(20).std()
+    regime = pd.cut(rolling_vol, bins=3, labels=["Calm", "Normal", "Wild"]).fillna("Calm")
+    summary = pd.DataFrame({"regime": regime, "return": equity.pct_change()}).groupby("regime").mean()
+    st.dataframe(summary)
+
+    st.subheader("Drawdown episodes")
+    episodes = pd.DataFrame(
+        {
+            "start": ["2022-01-01", "2022-03-15"],
+            "end": ["2022-02-20", "2022-04-01"],
+            "depth": [-0.12, -0.08],
+            "duration": [30, 20],
+        }
+    )
+    st.table(episodes)
+
+
+if __name__ == "__main__":
+    main()

--- a/streamlit_app/pages/12_⚙️_Options_Payoff_Studio.py
+++ b/streamlit_app/pages/12_⚙️_Options_Payoff_Studio.py
@@ -1,0 +1,47 @@
+"""Options strategy payoff visualiser."""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import streamlit as st
+
+
+def payoff(strikes, premiums, lots, price_grid):
+    payoff_matrix = np.zeros_like(price_grid, dtype=float)
+    for strike, premium, lot in zip(strikes, premiums, lots):
+        intrinsic = np.maximum(price_grid - strike, 0)
+        payoff_matrix += (intrinsic - premium) * lot
+    return payoff_matrix
+
+
+def main() -> None:
+    st.title("⚙️ Options Strategy Studio")
+    st.caption("Build custom spreads, visualise payoff, and review Greeks approximations.")
+
+    cols = st.columns(3)
+    strikes = st.text_input("Strikes", value="95,100,105")
+    premiums = st.text_input("Premiums", value="3.5,2.0,1.0")
+    lots = st.text_input("Lots", value="1,-2,1")
+    expiry = cols[0].date_input("Expiry")
+    implied_vol = cols[1].number_input("Implied vol", value=0.25)
+    margin = cols[2].number_input("Margin estimate", value=1000.0)
+
+    strikes_list = [float(x) for x in strikes.split(",")]
+    premiums_list = [float(x) for x in premiums.split(",")]
+    lots_list = [float(x) for x in lots.split(",")]
+    price_grid = np.linspace(min(strikes_list) * 0.8, max(strikes_list) * 1.2, 100)
+    payoff_values = payoff(strikes_list, premiums_list, lots_list, price_grid)
+
+    chart_df = pd.DataFrame({"Price": price_grid, "Payoff": payoff_values})
+    st.line_chart(chart_df.set_index("Price"))
+
+    st.subheader("Break-even points")
+    breakevens = price_grid[np.isclose(payoff_values, 0, atol=0.5)]
+    st.write(np.unique(np.round(breakevens, 2)))
+
+    st.subheader("Templates")
+    st.selectbox("Template", ["Custom", "Iron Condor", "Vertical Spread", "Butterfly", "Calendar"])
+
+
+if __name__ == "__main__":
+    main()

--- a/streamlit_app/pages/13_🗺️_Levels_Playbook.py
+++ b/streamlit_app/pages/13_🗺️_Levels_Playbook.py
@@ -1,0 +1,30 @@
+"""Levels and playbook planner."""
+from __future__ import annotations
+
+import json
+from datetime import date
+
+import streamlit as st
+
+
+def main() -> None:
+    st.title("🗺️ Levels & Playbook Planner")
+    st.caption("Prepare pre-market plans with key levels and scenarios.")
+
+    st.subheader("Key levels")
+    levels = st.text_area("Levels JSON", json.dumps({"HTF": [4300, 4250], "LTF": [4280]}, indent=2))
+    st.subheader("Bias & scenarios")
+    bias = st.selectbox("Bias", ["Bullish", "Neutral", "Bearish"])
+    scenarios = st.text_area("If-Then", "If open gap up, look for OR break -> fade")
+    checklist = st.multiselect(
+        "Session checklist", ["Review overnight session", "Mark economic events", "Sync with team"], default=["Review overnight session"]
+    )
+
+    st.subheader("Playbook PDF")
+    st.date_input("Session date", value=date.today())
+    st.button("Generate Playbook PDF")
+    st.info("HTML-to-PDF render handled locally via weasyprint/pdfkit.")
+
+
+if __name__ == "__main__":
+    main()

--- a/streamlit_app/pages/14_🏷️_Setup_Logger.py
+++ b/streamlit_app/pages/14_🏷️_Setup_Logger.py
@@ -1,0 +1,26 @@
+"""Setup and pattern logger."""
+from __future__ import annotations
+
+import streamlit as st
+
+
+def main() -> None:
+    st.title("🏷️ Setup / Pattern Logger")
+    st.caption("Build a gallery of your favourite trade setups with outcomes.")
+
+    st.subheader("Upload annotated chart")
+    image = st.file_uploader("Chart image", type=["png", "jpg", "jpeg"])
+    tags = st.text_input("Tags", value="ORBO,TrendDay")
+    outcome = st.selectbox("Outcome", ["Winner", "Loser", "Scratch"]) 
+    notes = st.text_area("Notes")
+    link_trade = st.text_input("Link to trade ID")
+
+    if st.button("Save setup"):
+        st.success("Image stored to data folder and metadata linked to trades table (extend logic).")
+
+    st.subheader("Gallery")
+    st.info("Display stored images with filters by tag and outcome.")
+
+
+if __name__ == "__main__":
+    main()

--- a/streamlit_app/pages/15_📐_Expectancy_Calc.py
+++ b/streamlit_app/pages/15_📐_Expectancy_Calc.py
@@ -1,0 +1,35 @@
+"""Expectancy calculator."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import streamlit as st
+
+PARENT = Path(__file__).resolve().parents[1]
+if str(PARENT) not in sys.path:
+    sys.path.append(str(PARENT))
+
+from utils import stats  # noqa: E402
+
+
+def main() -> None:
+    st.title("📐 Expectancy & Edge Calculator")
+    st.caption("Quick sanity checks on win-rate and payoff.")
+
+    win_rate = st.slider("Win rate", 0.1, 0.9, 0.5)
+    avg_win = st.number_input("Average win", value=200.0)
+    avg_loss = st.number_input("Average loss", value=-150.0)
+    costs = st.number_input("Trading costs per trade", value=10.0)
+
+    expectancy = stats.expectancy(avg_win - costs, avg_loss - costs, win_rate)
+    payoff = stats.payoff_ratio(avg_win, avg_loss)
+    st.metric("Expectancy / trade", f"{expectancy:.2f}")
+    st.metric("Payoff ratio", f"{payoff:.2f}")
+
+    st.subheader("Breakeven table")
+    st.table({"Win rate": [0.3, 0.4, 0.5], "Expectancy": [expectancy * 0.8, expectancy, expectancy * 1.2]})
+
+
+if __name__ == "__main__":
+    main()

--- a/streamlit_app/pages/16_📝_Session_Review.py
+++ b/streamlit_app/pages/16_📝_Session_Review.py
@@ -1,0 +1,45 @@
+"""Rule-based session review assistant."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import streamlit as st
+
+PARENT = Path(__file__).resolve().parents[1]
+if str(PARENT) not in sys.path:
+    sys.path.append(str(PARENT))
+
+
+def main() -> None:
+    st.title("📝 Session Review Assistant")
+    st.caption("Deterministic checklist to evaluate discipline.")
+
+    st.subheader("Checklist")
+    broke_risk = st.checkbox("Broke risk rule")
+    took_b = st.checkbox("Took B-grade setups")
+    revenge = st.checkbox("Revenge traded")
+    notes = st.text_area("Notes")
+
+    st.subheader("Scores")
+    score = 100
+    actions = []
+    if broke_risk:
+        score -= 30
+        actions.append("Reduce size tomorrow and review risk plan.")
+    if took_b:
+        score -= 20
+        actions.append("Limit to A setups only next session.")
+    if revenge:
+        score -= 25
+        actions.append("Implement 15-minute cool-off timer.")
+
+    st.metric("Session score", score)
+    st.write("Action items", actions or ["Great job! Keep following the plan."])
+
+    if st.button("Append to journal notes"):
+        st.success("Saved to SQLite notes column via trades aggregation (implement DB write).")
+
+
+if __name__ == "__main__":
+    main()

--- a/streamlit_app/pages/17_📚_Symbol_Notebook.py
+++ b/streamlit_app/pages/17_📚_Symbol_Notebook.py
@@ -1,0 +1,43 @@
+"""Symbol and sector notebook."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+import streamlit as st
+
+PARENT = Path(__file__).resolve().parents[1]
+if str(PARENT) not in sys.path:
+    sys.path.append(str(PARENT))
+
+
+def main() -> None:
+    st.title("📚 Symbol / Sector Notebook")
+    st.caption("Personal wiki of instruments and playbooks.")
+
+    st.subheader("Add entry")
+    symbol = st.text_input("Symbol", value="ES")
+    atr = st.number_input("Typical ATR", value=20.0)
+    timeframe = st.selectbox("Preferred timeframe", ["1m", "15m", "1h", "Daily"])
+    personal_rules = st.text_area("Personal rules", "Trade only during cash session.")
+    tags = st.text_input("Tags", "index,trend")
+
+    if st.button("Save note"):
+        st.success("Persist to SQLite levels/notes tables (implement).")
+
+    st.subheader("Notebook")
+    data = pd.DataFrame(
+        {
+            "symbol": ["ES", "NQ"],
+            "ATR": [20, 30],
+            "tags": ["index", "tech"],
+            "rules": ["Avoid Fed days", "Trade after Europe close"],
+        }
+    )
+    st.dataframe(data)
+    st.download_button("Export crib sheet", data.to_csv(index=False), file_name="symbol_notebook.csv")
+
+
+if __name__ == "__main__":
+    main()

--- a/streamlit_app/pages/18_🔬_Equity_Comparator.py
+++ b/streamlit_app/pages/18_🔬_Equity_Comparator.py
@@ -1,0 +1,41 @@
+"""Equity curve comparator."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import streamlit as st
+
+PARENT = Path(__file__).resolve().parents[1]
+if str(PARENT) not in sys.path:
+    sys.path.append(str(PARENT))
+
+from utils import charts  # noqa: E402
+
+
+def main() -> None:
+    st.title("🔬 Equity Curve Comparator")
+    st.caption("Overlay multiple strategies or baskets to inspect correlation and alpha.")
+
+    series_count = st.slider("Number of series", 2, 5, 3)
+    data = {
+        f"Series {i+1}": pd.Series(
+            np.cumprod(1 + np.random.normal(0.0005 * (i + 1), 0.01, 200)) * 10000
+        )
+        for i in range(series_count)
+    }
+
+    st.plotly_chart(charts.multi_equity_plot(data))
+    frame = pd.DataFrame(data)
+    st.subheader("Correlation matrix")
+    st.dataframe(frame.pct_change().corr())
+
+    st.subheader("Drawdown overlap")
+    dd = frame.apply(lambda col: col / col.cummax() - 1)
+    st.area_chart(dd)
+
+
+if __name__ == "__main__":
+    main()

--- a/streamlit_app/pages/19_🧱_Data_Synth.py
+++ b/streamlit_app/pages/19_🧱_Data_Synth.py
@@ -1,0 +1,46 @@
+"""Manual OHLCV data builder."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import streamlit as st
+
+PARENT = Path(__file__).resolve().parents[1]
+if str(PARENT) not in sys.path:
+    sys.path.append(str(PARENT))
+
+from utils import io  # noqa: E402
+
+
+def main() -> None:
+    st.title("🧱 Manual Data Builder")
+    st.caption("Generate synthetic OHLCV data for sandbox backtests.")
+
+    length = st.slider("Length", 50, 1000, 200)
+    volatility = st.slider("Volatility", 0.1, 5.0, 1.0)
+    drift = st.slider("Drift", -1.0, 1.0, 0.2)
+    spikes = st.slider("Spikes", 0, 10, 2)
+
+    base = np.cumsum(np.random.normal(drift / length, volatility / length, length))
+    price = 100 + base
+    high = price + np.random.uniform(0, 1, length)
+    low = price - np.random.uniform(0, 1, length)
+    open_price = price + np.random.uniform(-0.5, 0.5, length)
+    close = price
+    volume = np.random.randint(100, 1000, length)
+    df = pd.DataFrame({"open": open_price, "high": high, "low": low, "close": close, "volume": volume})
+
+    st.line_chart(df[["close"]])
+    st.dataframe(df.head())
+
+    if st.button("Save to daily_bars table"):
+        st.success("Persist generated data to SQLite via utils.db (implement).")
+
+    st.download_button("Export CSV", df.to_csv(index=False), file_name="synthetic_bars.csv")
+
+
+if __name__ == "__main__":
+    main()

--- a/streamlit_app/pages/1_📒_Trading_Journal.py
+++ b/streamlit_app/pages/1_📒_Trading_Journal.py
@@ -1,0 +1,146 @@
+"""Comprehensive trading journal page."""
+from __future__ import annotations
+
+import json
+import sys
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+import streamlit as st
+
+PARENT = Path(__file__).resolve().parents[1]
+if str(PARENT) not in sys.path:
+    sys.path.append(str(PARENT))
+
+from utils import charts, db, io  # noqa: E402
+
+
+def load_demo_trades() -> pd.DataFrame:
+    dates = pd.date_range(end=pd.Timestamp.today(), periods=20)
+    return pd.DataFrame(
+        {
+            "date": dates,
+            "symbol": ["ES"] * 10 + ["NQ"] * 10,
+            "direction": ["Long", "Short"] * 10,
+            "qty": 1,
+            "entry": 100 + pd.Series(range(20)),
+            "exit": 101 + pd.Series(range(20)),
+            "strategy": ["Mean Revert", "Breakout"] * 10,
+            "tags": ["A,Opening"] * 20,
+            "pnl": pd.Series(range(-5, 15)) * 50,
+        }
+    )
+
+
+def render_import_section():
+    st.subheader("Import trades")
+    uploaded = st.file_uploader("Upload CSV", type=["csv", "parquet"])
+    if uploaded is not None:
+        if uploaded.name.endswith(".csv"):
+            df = pd.read_csv(uploaded)
+        else:
+            df = pd.read_parquet(uploaded)
+        st.write("Detected columns:", df.columns.tolist())
+        st.dataframe(df.head())
+        if st.button("Map & Save to DB"):
+            db.init_db()
+            st.success("Trades saved (placeholder). Extend to map columns and insert into SQLite.")
+
+
+def render_manual_entry():
+    st.subheader("Manual trade entry")
+    with st.form("trade_entry"):
+        cols = st.columns(4)
+        trade_date = cols[0].date_input("Date", value=date.today())
+        symbol = cols[1].text_input("Symbol", value="ES")
+        direction = cols[2].selectbox("Direction", ["Long", "Short"])
+        qty = cols[3].number_input("Quantity", value=1.0)
+        entry = st.number_input("Entry", value=100.0)
+        exit_price = st.number_input("Exit", value=101.0)
+        fees = st.number_input("Fees", value=0.0)
+        sl = st.number_input("Stop Loss", value=98.0)
+        tp = st.number_input("Take Profit", value=105.0)
+        timeframe = st.selectbox("Timeframe", ["1m", "5m", "1h", "Daily"])
+        strategy = st.text_input("Strategy", value="Mean Reversion")
+        tags = st.text_input("Tags", value="Opening")
+        notes = st.text_area("Notes")
+        checklist = st.multiselect("Checklist", ["Plan followed", "Risk respected", "Setup qualified"])
+        screenshot = st.file_uploader("Screenshot", type=["png", "jpg", "jpeg"])
+        submitted = st.form_submit_button("Save Trade")
+        if submitted:
+            db.execute(
+                "INSERT INTO trades(date, symbol, segment, direction, qty, entry, exit, fees, sl, tp, timeframe, strategy, tags, notes, screenshot_path)"
+                " VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                (
+                    str(trade_date),
+                    symbol,
+                    "Futures",
+                    direction,
+                    qty,
+                    entry,
+                    exit_price,
+                    fees,
+                    sl,
+                    tp,
+                    timeframe,
+                    strategy,
+                    ",".join(checklist) if checklist else tags,
+                    notes,
+                    screenshot.name if screenshot else None,
+                ),
+            )
+            st.success("Trade stored. Attachments saved via desktop bundler logic.")
+
+
+def render_analytics(trades: pd.DataFrame):
+    st.subheader("Analytics")
+    if trades.empty:
+        st.info("No trades to show. Import data or enable demo mode.")
+        return
+    trades = trades.copy()
+    trades["equity"] = trades["pnl"].cumsum()
+    st.pyplot(charts.equity_curve_chart(trades.set_index("date")["equity"]))
+    st.plotly_chart(charts.histogram(trades["pnl"]))
+    streaks = trades["pnl"].gt(0).astype(int)
+    st.write("Win/Loss streak proxy:", streaks.value_counts())
+    st.dataframe(trades.groupby("strategy")["pnl"].sum().rename("P&L"))
+
+    st.subheader("Filters")
+    with st.expander("Filter trades"):
+        selected_symbol = st.selectbox("Symbol", ["All"] + sorted(trades["symbol"].unique().tolist()))
+        if selected_symbol != "All":
+            trades = trades[trades["symbol"] == selected_symbol]
+        st.write("Filtered rows", len(trades))
+
+    st.subheader("Reports")
+    st.button("Generate Daily PDF", help="Use utils.io + PDF engine to export.")
+    st.button("Generate Weekly PDF")
+
+
+def main() -> None:
+    st.title("📒 Trading Journal")
+    st.caption("Local-first journal with attachments, tags, and analytics.")
+
+    demo = st.checkbox("Use demo data", value=True)
+    trades = load_demo_trades() if demo else pd.DataFrame()
+
+    render_import_section()
+    render_manual_entry()
+
+    st.divider()
+    render_analytics(trades)
+
+    st.subheader("Tag Editor")
+    st.text_area("Manage tags", json.dumps({"Opening": "First 30m trades"}, indent=2))
+    st.button("Save Tags")
+
+    st.subheader("Attachment Gallery")
+    st.info("List and preview uploaded screenshots here.")
+
+    st.subheader("Export")
+    st.write("Download CSV, XLSX, PDF using the Export Center or quick buttons.")
+
+
+if __name__ == "__main__":
+    main()

--- a/streamlit_app/pages/20_📦_Export_Center.py
+++ b/streamlit_app/pages/20_📦_Export_Center.py
@@ -1,0 +1,34 @@
+"""Export center for all artefacts."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import streamlit as st
+
+PARENT = Path(__file__).resolve().parents[1]
+if str(PARENT) not in sys.path:
+    sys.path.append(str(PARENT))
+
+from utils import io  # noqa: E402
+
+
+def main() -> None:
+    st.title("📦 Export Center")
+    st.caption("One-stop shop for CSV/XLSX/PDF and zipped bundles.")
+
+    st.subheader("Trades & Stats")
+    st.button("Export trades to XLSX")
+    st.button("Export stats PDF pack")
+
+    st.subheader("Strategy bundle")
+    st.button("Zip strategies + rules")
+
+    st.subheader("Playbook & Weekly review")
+    st.button("Generate weekly PDF")
+
+    st.info("Leverage utils.io helpers for CSV/XLSX plus pdfkit/weasyprint for PDFs.")
+
+
+if __name__ == "__main__":
+    main()

--- a/streamlit_app/pages/2_📥_Import_Clean.py
+++ b/streamlit_app/pages/2_📥_Import_Clean.py
@@ -1,0 +1,65 @@
+"""Trade importer and cleaner."""
+from __future__ import annotations
+
+import io as sysio
+import re
+import sys
+from pathlib import Path
+
+import pandas as pd
+import streamlit as st
+
+PARENT = Path(__file__).resolve().parents[1]
+if str(PARENT) not in sys.path:
+    sys.path.append(str(PARENT))
+
+from utils import db, io  # noqa: E402
+
+
+def regex_helper(column: pd.Series, pattern: str) -> pd.Series:
+    compiled = re.compile(pattern)
+    return column.astype(str).str.extract(compiled, expand=False)
+
+
+def main() -> None:
+    st.title("📥 Trade Importer & Cleaner")
+    st.caption("Standardise messy broker exports before journaling.")
+
+    uploaded = st.file_uploader("Upload raw trade CSV", type=["csv"])
+    mapper_col1, mapper_col2 = st.columns(2)
+    date_format = mapper_col1.text_input("Date format", value="%Y-%m-%d")
+    regex_pattern = mapper_col2.text_input("Regex helper", value=r"([A-Z]{1,5})")
+
+    if uploaded:
+        raw = pd.read_csv(uploaded)
+        st.write("Preview", raw.head())
+
+        with st.expander("Column mapper"):
+            mapping = {}
+            for col in raw.columns:
+                mapping[col] = st.selectbox(
+                    f"Map column `{col}`", ["ignore", "date", "symbol", "qty", "price", "fees", "direction"], key=col
+                )
+            st.json(mapping)
+
+        if st.checkbox("Apply regex helper"):
+            target_col = st.selectbox("Column to parse", raw.columns)
+            raw[target_col] = regex_helper(raw[target_col], regex_pattern)
+            st.write("Regex applied", raw[target_col].head())
+
+        if st.button("Clean & Download"):
+            cleaned = raw.rename(columns={col: dest for col, dest in mapping.items() if dest != "ignore"})
+            buffer = sysio.StringIO()
+            cleaned.to_csv(buffer, index=False)
+            st.download_button("Download cleaned CSV", buffer.getvalue(), file_name="clean_trades.csv")
+
+        if st.button("Write into Journal DB"):
+            db.init_db()
+            st.success("Would insert cleaned records into trades table (extend as needed).")
+
+    st.subheader("Extras")
+    st.write("Deduping, fee normalization, and corporate action adjustment placeholders ready.")
+
+
+if __name__ == "__main__":
+    main()

--- a/streamlit_app/pages/3_📈_Performance_Analytics.py
+++ b/streamlit_app/pages/3_📈_Performance_Analytics.py
@@ -1,0 +1,59 @@
+"""Performance analytics dashboards."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import streamlit as st
+
+PARENT = Path(__file__).resolve().parents[1]
+if str(PARENT) not in sys.path:
+    sys.path.append(str(PARENT))
+
+from utils import charts, stats  # noqa: E402
+
+
+def demo_equity() -> pd.Series:
+    dates = pd.date_range(end=pd.Timestamp.today(), periods=250)
+    returns = np.random.normal(0.001, 0.01, len(dates))
+    equity = (1 + pd.Series(returns, index=dates)).cumprod() * 10000
+    return equity
+
+
+def main() -> None:
+    st.title("📈 Performance Analytics & Reports")
+    st.caption("Deep statistics, rolling metrics, and exportable packs.")
+
+    equity = demo_equity()
+    returns = equity.pct_change().dropna()
+
+    metrics_col1, metrics_col2, metrics_col3 = st.columns(3)
+    metrics_col1.metric("CAGR", f"{stats.cagr(equity):.2%}")
+    metrics_col2.metric("Sharpe", f"{stats.sharpe_ratio(returns):.2f}")
+    metrics_col3.metric("Max DD", f"{stats.max_drawdown(equity):.2%}")
+
+    st.plotly_chart(charts.histogram(returns, bins=30), use_container_width=True)
+
+    with st.expander("Rolling stats"):
+        window = st.slider("Window", min_value=10, max_value=100, value=30)
+        rolling_sharpe = returns.rolling(window).mean() / returns.rolling(window).std()
+        st.line_chart(rolling_sharpe, height=200)
+        st.line_chart(returns.cumsum(), height=200)
+
+    st.subheader("Underwater curve")
+    dd = equity / equity.cummax() - 1
+    st.area_chart(dd, height=200)
+
+    st.subheader("Edge by time")
+    hourly = pd.DataFrame({"hour": np.arange(0, 24), "avg_R": np.random.uniform(-0.1, 0.2, 24)})
+    st.bar_chart(hourly.set_index("hour"))
+
+    st.subheader("Exports")
+    st.button("Generate Daily PDF pack")
+    st.button("Generate Weekly PDF pack")
+
+
+if __name__ == "__main__":
+    main()

--- a/streamlit_app/pages/4_🧮_Position_Sizing_Lab.py
+++ b/streamlit_app/pages/4_🧮_Position_Sizing_Lab.py
@@ -1,0 +1,62 @@
+"""Position sizing lab."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+import streamlit as st
+
+PARENT = Path(__file__).resolve().parents[1]
+if str(PARENT) not in sys.path:
+    sys.path.append(str(PARENT))
+
+from utils import sizing, stats  # noqa: E402
+
+
+def main() -> None:
+    st.title("🧮 Position Sizing Lab")
+    st.caption("Compute position sizes across multiple risk models.")
+
+    account_size = st.number_input("Account size", value=50000.0)
+    entry = st.number_input("Entry price", value=100.0)
+    stop = st.number_input("Stop loss", value=95.0)
+    target = st.number_input("Target", value=110.0)
+    risk_pct = st.slider("Risk %", min_value=0.1, max_value=5.0, value=1.0)
+    atr = st.number_input("ATR", value=2.5)
+    multiplier = st.slider("ATR multiplier", 0.5, 5.0, value=1.0)
+    win_rate = st.slider("Win rate", 0.1, 0.9, value=0.45)
+    payoff = st.slider("Payoff ratio", 0.5, 5.0, value=1.8)
+
+    stop_distance = abs(entry - stop)
+    risk_amount = account_size * (risk_pct / 100)
+    fixed_fraction = sizing.fixed_fractional(account_size, risk_pct / 100, stop_distance)
+    fixed_risk_size = sizing.fixed_risk(risk_amount, stop_distance)
+    atr_based_size = sizing.atr_based(account_size, atr, multiplier, atr)
+    kelly_fraction = sizing.kelly_fraction(win_rate, payoff)
+
+    st.metric("Fixed Fractional size", f"{fixed_fraction:.2f} units")
+    st.metric("Fixed Risk size", f"{fixed_risk_size:.2f} units")
+    st.metric("ATR-based size", f"{atr_based_size:.2f} units")
+    st.metric("Kelly fraction", f"{kelly_fraction:.2%}")
+
+    projected_profit = (target - entry) * fixed_fraction
+    projected_loss = (entry - stop) * fixed_fraction
+    st.write("Projected P&L ladder")
+    ladder = pd.DataFrame(
+        {
+            "R Multiple": [-1, -0.5, 0, 1, 2, 3],
+            "P&L": [projected_loss, projected_loss / 2, 0, projected_profit, projected_profit * 2, projected_profit * 3],
+        }
+    )
+    st.table(ladder)
+
+    st.subheader("Risk of Ruin")
+    st.write(stats.risk_of_ruin(win_rate, payoff, capital_r_multiple=100))
+
+    st.subheader("Modes")
+    st.write("Fixed-fractional, fixed-risk, fixed-units, ATR-based, Kelly — toggle between them above.")
+
+
+if __name__ == "__main__":
+    main()

--- a/streamlit_app/pages/5_🚨_Risk_Dashboard.py
+++ b/streamlit_app/pages/5_🚨_Risk_Dashboard.py
@@ -1,0 +1,64 @@
+"""Risk dashboard enforcing account heat limits."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+import streamlit as st
+
+PARENT = Path(__file__).resolve().parents[1]
+if str(PARENT) not in sys.path:
+    sys.path.append(str(PARENT))
+
+from utils import charts  # noqa: E402
+
+
+def demo_open_trades() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "symbol": ["ES", "NQ", "CL"],
+            "entry": [4100, 12500, 72],
+            "stop": [4050, 12300, 68],
+            "size": [2, 1, 3],
+            "risk": [1000, 1000, 1200],
+            "tags": ["Index", "Index", "Energy"],
+        }
+    )
+
+
+def main() -> None:
+    st.title("🚨 Risk Dashboard (Account Heat)")
+    st.caption("Stress-test proposed trades against risk policy.")
+
+    profile = st.selectbox("Risk profile", ["Default", "Aggressive", "Conservative"])
+    max_risk_trade = st.number_input("Max risk per trade", value=1000.0)
+    max_portfolio_heat = st.number_input("Max portfolio heat", value=4000.0)
+
+    st.subheader("Open / Proposed trades")
+    trades = demo_open_trades()
+    st.dataframe(trades)
+
+    total_risk = trades["risk"].sum()
+    breaches = trades[trades["risk"] > max_risk_trade]
+    st.metric("Total portfolio heat", f"${total_risk:,.0f}")
+
+    if total_risk > max_portfolio_heat:
+        st.error("Portfolio heat exceeds limit. Reduce sizes or skip trades.")
+    else:
+        st.success("Within heat limits.")
+
+    if not breaches.empty:
+        st.warning("Trades breaching per-trade risk:")
+        st.dataframe(breaches)
+
+    st.subheader("Segment exposure")
+    segment_exposure = trades.groupby("tags")["risk"].sum()
+    st.plotly_chart(charts.risk_gauge(segment_exposure.values))
+
+    st.subheader("Actionable deltas")
+    st.write("Reduce ES by 0.5 lots, widen CL stop by 0.5, skip NQ if adding new positions.")
+
+
+if __name__ == "__main__":
+    main()

--- a/streamlit_app/pages/6_🗄️_Strategy_Vault.py
+++ b/streamlit_app/pages/6_🗄️_Strategy_Vault.py
@@ -1,0 +1,60 @@
+"""Strategy vault file manager."""
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+import streamlit as st
+
+PARENT = Path(__file__).resolve().parents[1]
+if str(PARENT) not in sys.path:
+    sys.path.append(str(PARENT))
+
+from utils import db  # noqa: E402
+
+
+def file_checksum(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def main() -> None:
+    st.title("🗄️ Strategy Vault")
+    st.caption("Store PDFs, code files, and metadata locally.")
+
+    uploaded = st.file_uploader("Upload strategy artifact", type=["pdf", "txt", "py", "json"])
+    strategy_name = st.text_input("Strategy name")
+    strategy_type = st.selectbox("Type", ["Intraday", "Swing", "Options"])
+    tags = st.text_input("Tags", value="momentum,trend")
+    rules = st.text_area("Rules (JSON)", value=json.dumps({"entry": "EMA cross"}, indent=2))
+
+    if uploaded and st.button("Save strategy"):
+        checksum = file_checksum(uploaded.getvalue())
+        file_path = Path("data") / f"{strategy_name}_{checksum[:8]}_{uploaded.name}"
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_bytes(uploaded.getvalue())
+        db.upsert(
+            "strategies",
+            {
+                "name": strategy_name,
+                "type": strategy_type,
+                "rules_json": rules,
+                "capital_req": 0,
+                "tags": tags,
+                "file_path": str(file_path),
+            },
+        )
+        st.success("Strategy stored with checksum versioning.")
+
+    st.subheader("Saved strategies")
+    records = db.fetch_all("SELECT name, type, tags, file_path FROM strategies ORDER BY name")
+    st.dataframe(pd.DataFrame(records))
+
+    st.subheader("Preview")
+    st.info("Quick preview of text-based files shown here.")
+
+
+if __name__ == "__main__":
+    main()

--- a/streamlit_app/pages/7_🧺_Basket_Composer.py
+++ b/streamlit_app/pages/7_🧺_Basket_Composer.py
@@ -1,0 +1,56 @@
+"""Strategy basket composer."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import streamlit as st
+
+PARENT = Path(__file__).resolve().parents[1]
+if str(PARENT) not in sys.path:
+    sys.path.append(str(PARENT))
+
+from utils import charts, db  # noqa: E402
+
+
+def demo_components() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "strategy": ["Mean Revert", "Breakout", "Options"],
+            "weight": [0.4, 0.4, 0.2],
+            "equity": [np.linspace(10000, 12000, 50), np.linspace(10000, 15000, 50), np.linspace(10000, 13000, 50)],
+        }
+    )
+
+
+def main() -> None:
+    st.title("🧺 Strategy Basket Composer")
+    st.caption("Blend strategies into deployable portfolios.")
+
+    strategies = [row["name"] for row in db.fetch_all("SELECT name FROM strategies")] or ["Mean Revert", "Breakout"]
+    selected = st.multiselect("Select strategies", strategies, default=strategies)
+    weights = {name: st.slider(f"Weight for {name}", 0.0, 1.0, 1 / max(len(selected), 1)) for name in selected}
+
+    st.subheader("Constraints")
+    st.number_input("Max concurrent positions", value=5, step=1)
+    st.number_input("Segment cap %", value=30, step=5)
+
+    st.subheader("Backfill & Simulation")
+    st.write("Use journal trades or uploaded return series to compute portfolio equity.")
+
+    comp = demo_components()
+    equity_df = pd.DataFrame({row.strategy: pd.Series(row.equity) for row in comp.itertuples()})
+    st.plotly_chart(charts.multi_equity_plot(equity_df.to_dict(orient="series")))
+
+    st.subheader("Attribution")
+    st.bar_chart(pd.Series(weights))
+
+    st.subheader("Rebalancing")
+    st.selectbox("Rule", ["Monthly", "Quarterly", "Drift > 5%"])
+
+
+if __name__ == "__main__":
+    main()

--- a/streamlit_app/pages/8_🔁_Backtest_Runner.py
+++ b/streamlit_app/pages/8_🔁_Backtest_Runner.py
@@ -1,0 +1,46 @@
+"""Offline backtest runner."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import streamlit as st
+
+PARENT = Path(__file__).resolve().parents[1]
+if str(PARENT) not in sys.path:
+    sys.path.append(str(PARENT))
+
+from utils import charts, rules  # noqa: E402
+
+
+def main() -> None:
+    st.title("🔁 Backtest Runner")
+    st.caption("Vectorised rule testing on uploaded OHLCV data.")
+
+    uploaded = st.file_uploader("Upload OHLCV", type=["csv", "parquet"])
+    if uploaded:
+        if uploaded.name.endswith(".csv"):
+            data = pd.read_csv(uploaded, parse_dates=["date"], infer_datetime_format=True)
+        else:
+            data = pd.read_parquet(uploaded)
+        st.dataframe(data.head())
+    else:
+        dates = pd.date_range(end=pd.Timestamp.today(), periods=100)
+        data = pd.DataFrame({"date": dates, "close": np.linspace(100, 120, 100) + np.random.randn(100)})
+
+    entry_rule = st.text_input("Entry rule", value="close > close.shift(1)")
+    exit_rule = st.text_input("Exit rule", value="close < close.shift(1)")
+
+    block = rules.RuleBlock("entry", "Simple momentum", entry_rule)
+    signals = block.evaluate(data.set_index("date"))
+    st.write("Sample signals", signals.head())
+
+    st.subheader("Results")
+    st.line_chart(data.set_index("date")["close"], height=200)
+    st.info("Extend with trade list, equity curve, parameter sweeps, and walk-forward splits.")
+
+
+if __name__ == "__main__":
+    main()

--- a/streamlit_app/pages/9_🧪_Walk_Forward.py
+++ b/streamlit_app/pages/9_🧪_Walk_Forward.py
@@ -1,0 +1,41 @@
+"""Walk-forward optimisation page."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import streamlit as st
+
+PARENT = Path(__file__).resolve().parents[1]
+if str(PARENT) not in sys.path:
+    sys.path.append(str(PARENT))
+
+
+def main() -> None:
+    st.title("🧪 Walk-Forward & OOS Validator")
+    st.caption("Split data into training/testing folds to fight overfitting.")
+
+    data_points = st.slider("Data points", min_value=100, max_value=1000, value=300)
+    folds = st.slider("Folds", min_value=2, max_value=10, value=3)
+    param_grid = st.text_area("Parameter grid", "sma=10,20,50\nrsi=20,30")
+
+    st.subheader("Results")
+    metrics = pd.DataFrame(
+        {
+            "fold": range(1, folds + 1),
+            "in_sample": np.random.uniform(0.5, 1.5, folds),
+            "out_sample": np.random.uniform(0.3, 1.2, folds),
+        }
+    )
+    metrics["stability"] = metrics["out_sample"] / metrics["in_sample"]
+    st.dataframe(metrics)
+    st.line_chart(metrics.set_index("fold"))
+
+    st.subheader("Best-on-median heuristic")
+    st.write("Select params that perform closest to the median across folds.")
+
+
+if __name__ == "__main__":
+    main()

--- a/streamlit_app/utils/__init__.py
+++ b/streamlit_app/utils/__init__.py
@@ -1,0 +1,4 @@
+"""Utility package for the Streamlit trading suite."""
+from . import charts, db, io, rules, sizing, stats  # noqa: F401
+
+__all__ = ["charts", "db", "io", "rules", "sizing", "stats"]

--- a/streamlit_app/utils/charts.py
+++ b/streamlit_app/utils/charts.py
@@ -1,0 +1,49 @@
+"""Chart helpers built on matplotlib and plotly."""
+from __future__ import annotations
+
+from typing import Iterable
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import plotly.express as px
+
+
+def equity_curve_chart(equity: pd.Series):
+    fig, ax = plt.subplots()
+    equity.plot(ax=ax)
+    ax.set_title("Equity Curve")
+    ax.set_xlabel("Date")
+    ax.set_ylabel("Equity")
+    ax.grid(True)
+    return fig
+
+
+def histogram(series: pd.Series, bins: int = 20):
+    fig = px.histogram(series, nbins=bins, title="Distribution")
+    fig.update_layout(bargap=0.1)
+    return fig
+
+
+def multi_equity_plot(series_dict: dict[str, pd.Series]):
+    fig = px.line(pd.DataFrame(series_dict))
+    fig.update_layout(title="Equity Comparison", xaxis_title="Date", yaxis_title="Equity")
+    return fig
+
+
+def calendar_heatmap(df: pd.DataFrame, value_col: str):
+    pivot = df.pivot(index="week", columns="weekday", values=value_col).fillna(0)
+    fig, ax = plt.subplots()
+    im = ax.imshow(pivot.values, cmap="RdYlGn")
+    ax.set_xticks(range(len(pivot.columns)))
+    ax.set_xticklabels(pivot.columns)
+    ax.set_yticks(range(len(pivot.index)))
+    ax.set_yticklabels(pivot.index)
+    ax.set_title("Calendar Heatmap")
+    fig.colorbar(im, ax=ax)
+    return fig
+
+
+def risk_gauge(values: Iterable[float]):
+    series = pd.Series(list(values))
+    fig = px.bar(series, title="Risk Exposure", labels={"index": "Item", "value": "Risk"})
+    return fig

--- a/streamlit_app/utils/db.py
+++ b/streamlit_app/utils/db.py
@@ -1,0 +1,144 @@
+"""Database utilities for the desktop Streamlit trading suite."""
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterable, Optional
+
+DB_FILE = Path(__file__).resolve().parents[1] / "app.db"
+SCHEMA_VERSION = 1
+
+TABLE_DEFINITIONS: dict[str, str] = {
+    "schema_version": (
+        "CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL)"
+    ),
+    "trades": (
+        "CREATE TABLE IF NOT EXISTS trades ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "date TEXT,"
+        "symbol TEXT,"
+        "segment TEXT,"
+        "direction TEXT,"
+        "qty REAL,"
+        "entry REAL,"
+        "exit REAL,"
+        "fees REAL,"
+        "sl REAL,"
+        "tp REAL,"
+        "timeframe TEXT,"
+        "strategy TEXT,"
+        "tags TEXT,"
+        "notes TEXT,"
+        "screenshot_path TEXT"
+        ")"
+    ),
+    "daily_bars": (
+        "CREATE TABLE IF NOT EXISTS daily_bars ("
+        "symbol TEXT,"
+        "date TEXT,"
+        "o REAL,"
+        "h REAL,"
+        "l REAL,"
+        "c REAL,"
+        "v REAL,"
+        "source_file TEXT,"
+        "PRIMARY KEY(symbol, date)"
+        ")"
+    ),
+    "returns": (
+        "CREATE TABLE IF NOT EXISTS returns ("
+        "date TEXT,"
+        "symbol TEXT,"
+        "ret REAL,"
+        "PRIMARY KEY(date, symbol)"
+        ")"
+    ),
+    "levels": (
+        "CREATE TABLE IF NOT EXISTS levels ("
+        "symbol TEXT,"
+        "level_type TEXT,"
+        "price REAL,"
+        "date TEXT,"
+        "confidence REAL,"
+        "notes TEXT"
+        ")"
+    ),
+    "strategies": (
+        "CREATE TABLE IF NOT EXISTS strategies ("
+        "name TEXT PRIMARY KEY,"
+        "type TEXT,"
+        "rules_json TEXT,"
+        "capital_req REAL,"
+        "tags TEXT,"
+        "file_path TEXT"
+        ")"
+    ),
+    "baskets": (
+        "CREATE TABLE IF NOT EXISTS baskets ("
+        "name TEXT PRIMARY KEY,"
+        "components_json TEXT,"
+        "capital_split_json TEXT,"
+        "rebal_rule TEXT,"
+        "notes TEXT"
+        ")"
+    ),
+    "risk_settings": (
+        "CREATE TABLE IF NOT EXISTS risk_settings ("
+        "profile_name TEXT PRIMARY KEY,"
+        "max_dd REAL,"
+        "risk_per_trade REAL,"
+        "kelly_cap REAL,"
+        "heat_limits_json TEXT"
+        ")"
+    ),
+}
+
+
+def init_db(db_file: Optional[Path] = None) -> None:
+    """Initialise the SQLite database and ensure schema version."""
+    db_path = db_file or DB_FILE
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        cursor = conn.cursor()
+        for ddl in TABLE_DEFINITIONS.values():
+            cursor.execute(ddl)
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='schema_version'")
+        if cursor.fetchone() is None:
+            cursor.execute(TABLE_DEFINITIONS["schema_version"])
+            cursor.execute("INSERT INTO schema_version(version) VALUES (?)", (SCHEMA_VERSION,))
+        conn.commit()
+
+
+@contextmanager
+def get_connection(db_file: Optional[Path] = None):
+    """Yield a SQLite connection with row factory set to dictionary-like output."""
+    db_path = db_file or DB_FILE
+    init_db(db_path)
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def execute(query: str, params: Iterable | None = None) -> None:
+    """Execute a write query."""
+    with get_connection() as conn:
+        conn.execute(query, params or [])
+        conn.commit()
+
+
+def fetch_all(query: str, params: Iterable | None = None) -> list[sqlite3.Row]:
+    with get_connection() as conn:
+        cur = conn.execute(query, params or [])
+        return cur.fetchall()
+
+
+def upsert(table: str, data: dict) -> None:
+    """Simple UPSERT helper using INSERT OR REPLACE."""
+    columns = ",".join(data.keys())
+    placeholders = ":" + ",:".join(data.keys())
+    sql = f"INSERT OR REPLACE INTO {table} ({columns}) VALUES ({placeholders})"
+    execute(sql, data)

--- a/streamlit_app/utils/io.py
+++ b/streamlit_app/utils/io.py
@@ -1,0 +1,49 @@
+"""File IO helpers for the Streamlit desktop suite."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+
+DATA_DIR = Path(__file__).resolve().parents[1] / "data"
+DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def load_table_csv(file: Path, encoding: str = "utf-8") -> pd.DataFrame:
+    return pd.read_csv(file, encoding=encoding)
+
+
+def load_table_parquet(file: Path) -> pd.DataFrame:
+    return pd.read_parquet(file)
+
+
+def save_dataframe(df: pd.DataFrame, path: Path, fmt: str = "csv") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if fmt == "csv":
+        df.to_csv(path, index=False)
+    elif fmt == "xlsx":
+        df.to_excel(path, index=False)
+    elif fmt == "parquet":
+        df.to_parquet(path, index=False)
+    else:
+        raise ValueError(f"Unsupported format: {fmt}")
+    return path
+
+
+def save_json(data: dict | list, path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)
+    return path
+
+
+def export_zip(files: Iterable[Path], dest: Path) -> Path:
+    import zipfile
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(dest, "w", zipfile.ZIP_DEFLATED) as archive:
+        for file in files:
+            archive.write(file, arcname=file.name)
+    return dest

--- a/streamlit_app/utils/rules.py
+++ b/streamlit_app/utils/rules.py
@@ -1,0 +1,29 @@
+"""Rule building helpers for strategy/backtest configuration."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+import pandas as pd
+
+
+@dataclass
+class RuleBlock:
+    name: str
+    description: str
+    expression: str
+    parameters: dict[str, Any] = field(default_factory=dict)
+
+    def evaluate(self, data: pd.DataFrame) -> pd.Series:
+        local_dict = {**self.parameters, "df": data}
+        return data.eval(self.expression, local_dict)
+
+
+def combine_rules(*rules: Callable[[pd.DataFrame], pd.Series]) -> Callable[[pd.DataFrame], pd.Series]:
+    def _combined(df: pd.DataFrame) -> pd.Series:
+        result = pd.Series(True, index=df.index)
+        for rule in rules:
+            result &= rule(df)
+        return result
+
+    return _combined

--- a/streamlit_app/utils/sizing.py
+++ b/streamlit_app/utils/sizing.py
@@ -1,0 +1,42 @@
+"""Position sizing helpers."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+def fixed_fractional(account_size: float, risk_pct: float, stop_distance: float) -> float:
+    risk_amount = account_size * risk_pct
+    if stop_distance <= 0:
+        return 0.0
+    return risk_amount / stop_distance
+
+
+def fixed_units(units: float) -> float:
+    return units
+
+
+def fixed_risk(risk_amount: float, stop_distance: float) -> float:
+    if stop_distance <= 0:
+        return 0.0
+    return risk_amount / stop_distance
+
+
+def atr_based(account_size: float, atr: float, multiplier: float, atr_value: float) -> float:
+    if atr <= 0:
+        return 0.0
+    return account_size * multiplier / atr_value if atr_value else 0.0
+
+
+def kelly_fraction(win_rate: float, payoff: float) -> float:
+    edge = win_rate - (1 - win_rate) / payoff if payoff else 0.0
+    if edge <= 0:
+        return 0.0
+    return edge / payoff
+
+
+@dataclass
+class RiskSummary:
+    position_size: float
+    r_multiple: float
+    projected_profit: float
+    projected_loss: float

--- a/streamlit_app/utils/stats.py
+++ b/streamlit_app/utils/stats.py
@@ -1,0 +1,53 @@
+"""Statistical helper functions."""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def cagr(equity: pd.Series) -> float:
+    if equity.empty:
+        return 0.0
+    years = (equity.index[-1] - equity.index[0]).days / 365.25
+    if years <= 0:
+        return 0.0
+    return float((equity.iloc[-1] / equity.iloc[0]) ** (1 / years) - 1)
+
+
+def sharpe_ratio(returns: pd.Series, risk_free: float = 0.0) -> float:
+    if returns.std() == 0:
+        return 0.0
+    excess = returns - risk_free / len(returns)
+    return float(np.sqrt(252) * excess.mean() / excess.std())
+
+
+def sortino_ratio(returns: pd.Series, risk_free: float = 0.0) -> float:
+    downside = returns[returns < 0]
+    if downside.std() == 0:
+        return 0.0
+    excess = returns - risk_free / len(returns)
+    return float(np.sqrt(252) * excess.mean() / downside.std())
+
+
+def max_drawdown(equity: pd.Series) -> float:
+    if equity.empty:
+        return 0.0
+    cummax = equity.cummax()
+    drawdowns = equity / cummax - 1
+    return float(drawdowns.min())
+
+
+def expectancy(avg_win: float, avg_loss: float, win_rate: float, loss_rate: float | None = None) -> float:
+    loss_rate = loss_rate if loss_rate is not None else 1 - win_rate
+    return avg_win * win_rate + avg_loss * loss_rate
+
+
+def payoff_ratio(avg_win: float, avg_loss: float) -> float:
+    return abs(avg_win / avg_loss) if avg_loss else 0.0
+
+
+def risk_of_ruin(win_rate: float, payoff: float, capital_r_multiple: float) -> float:
+    edge = win_rate - (1 - win_rate) / payoff if payoff else 0
+    if edge <= 0:
+        return 1.0
+    return float(((1 - edge) / (1 + edge)) ** capital_r_multiple)


### PR DESCRIPTION
## Summary
- scaffold Streamlit desktop project with home landing page and 20 feature-specific subpages
- implement shared utilities for SQLite persistence, file IO, charting, statistics, sizing, and rule blocks
- add placeholder interactions across journal, analytics, risk, strategy, simulation, and export workflows referencing local storage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df4e0334e0832293719dcce927bfc1